### PR TITLE
Update tex2ngl.py to work for more types of images

### DIFF
--- a/tools/tex2ngl.py
+++ b/tools/tex2ngl.py
@@ -13,7 +13,7 @@ def color2ngl(r, g, b, _=0):
 
 def tex2ngl(src):
     """Converts src to C header containing nGL TEXTURE. Returns tuple(code, object name, tuple(w, h))."""
-    img = Image.open(src)
+    img = Image.open(src).convert("RGBA")
     width, height = img.size
     name = ngl_name(os.path.splitext(os.path.basename(src))[0])
 


### PR DESCRIPTION
I recently found that tex2ngl currently doesn't work for images which aren't in RGB or RGBA format (for example, PNGs in indexed mode). PIL's `Image.convert()` method is an easy fix

