### PR TITLE
Added orthographic mode

### DIFF
--- a/gl.cpp
+++ b/gl.cpp
@@ -828,8 +828,8 @@ void glBindTexture(const TEXTURE *tex)
 {
     texture = tex;
 
-    //if(tex && tex->has_transparency && tex->transparent_color != 0)
-        //printf("Bound texture doesn't have black as transparent color!\n");
+    if(tex && tex->has_transparency && tex->transparent_color != 0)
+        printf("Bound texture doesn't have black as transparent color!\n");
 }
 
 void nglSetNearPlane(const GLFix new_near_plane)

--- a/gl.cpp
+++ b/gl.cpp
@@ -18,6 +18,7 @@ static SDL_Surface *scr;
 #define P(m, y, x) (m->data[y][x])
 
 MATRIX *transformation;
+static GLProjectionMode projection_mode = GLProjectionMode::GL_PROJECTION_PERSPECTIVE; //Default mode is perspective
 static COLOR color;
 static GLFix u, v;
 static COLOR *screen;
@@ -27,7 +28,9 @@ static const TEXTURE *texture;
 static unsigned int vertices_count = 0;
 static VERTEX vertices[4];
 static GLDrawMode draw_mode = GL_TRIANGLES;
+#ifdef _TINSPIRE
 static bool is_monochrome;
+#endif
 static COLOR *screen_inverted; //For monochrome calcs
 #ifdef FPS_COUNTER
     volatile unsigned int fps;
@@ -133,8 +136,14 @@ void nglMultMatVectRes(const MATRIX *mat1, const VECTOR3 *vect, VECTOR3 *res)
     res->z = P(mat1, 2, 0)*x + P(mat1, 2, 1)*y + P(mat1, 2, 2)*z + P(mat1, 2, 3);
 }
 
+void nglSetProjectionMode(GLProjectionMode mode) {
+    projection_mode = mode;
+}
+
 void nglPerspective(VERTEX *v)
 {
+    if (projection_mode == GL_PROJECTION_ORTHOGRAPHIC)
+        return; //Ortho mode
 #ifdef BETTER_PERSPECTIVE
     float new_z = v->z;
     decltype(new_z) new_x = v->x, new_y = v->y;
@@ -188,6 +197,8 @@ void nglPerspective(VERTEX *v)
 
 void nglPerspective(VECTOR3 *v)
 {
+    if (projection_mode == GL_PROJECTION_ORTHOGRAPHIC)
+        return; //Ortho mode
 #ifdef BETTER_PERSPECTIVE
     float new_z = v->z;
     decltype(new_z) new_x = v->x, new_y = v->y;
@@ -817,8 +828,8 @@ void glBindTexture(const TEXTURE *tex)
 {
     texture = tex;
 
-    if(tex && tex->has_transparency && tex->transparent_color != 0)
-        printf("Bound texture doesn't have black as transparent color!\n");
+    //if(tex && tex->has_transparency && tex->transparent_color != 0)
+        //printf("Bound texture doesn't have black as transparent color!\n");
 }
 
 void nglSetNearPlane(const GLFix new_near_plane)

--- a/gl.cpp
+++ b/gl.cpp
@@ -136,7 +136,8 @@ void nglMultMatVectRes(const MATRIX *mat1, const VECTOR3 *vect, VECTOR3 *res)
     res->z = P(mat1, 2, 0)*x + P(mat1, 2, 1)*y + P(mat1, 2, 2)*z + P(mat1, 2, 3);
 }
 
-void nglSetProjectionMode(GLProjectionMode mode) {
+void nglSetProjectionMode(GLProjectionMode mode)
+{
     projection_mode = mode;
 }
 

--- a/gl.cpp
+++ b/gl.cpp
@@ -200,6 +200,7 @@ void nglPerspective(VECTOR3 *v)
 {
     if (projection_mode == GL_PROJECTION_ORTHOGRAPHIC)
         return; //Ortho mode
+    
 #ifdef BETTER_PERSPECTIVE
     float new_z = v->z;
     decltype(new_z) new_x = v->x, new_y = v->y;

--- a/gl.cpp
+++ b/gl.cpp
@@ -29,9 +29,9 @@ static unsigned int vertices_count = 0;
 static VERTEX vertices[4];
 static GLDrawMode draw_mode = GL_TRIANGLES;
 #ifdef _TINSPIRE
-static bool is_monochrome;
+    static bool is_monochrome;
+    static COLOR *screen_inverted; //For monochrome calcs
 #endif
-static COLOR *screen_inverted; //For monochrome calcs
 #ifdef FPS_COUNTER
     volatile unsigned int fps;
 #endif
@@ -77,10 +77,9 @@ void nglUninit()
     uninit_fastmath();
     delete[] transformation;
     delete[] z_buffer;
-
-    delete[] screen_inverted;
-
+    
     #ifdef _TINSPIRE
+        delete[] screen_inverted;
         lcd_init(SCR_TYPE_INVALID);
     #else
         //TODO
@@ -145,6 +144,7 @@ void nglPerspective(VERTEX *v)
 {
     if (projection_mode == GL_PROJECTION_ORTHOGRAPHIC)
         return; //Ortho mode
+
 #ifdef BETTER_PERSPECTIVE
     float new_z = v->z;
     decltype(new_z) new_x = v->x, new_y = v->y;

--- a/gl.h
+++ b/gl.h
@@ -132,6 +132,13 @@ struct RGB
 #endif
 extern MATRIX *transformation;
 
+enum GLProjectionMode
+{
+    GL_PROJECTION_PERSPECTIVE,
+    GL_PROJECTION_ORTHOGRAPHIC
+};
+
+
 RGB rgbColor(const COLOR c);
 COLOR colorRGB(const RGB rgb);
 COLOR colorRGB(const GLFix r, const GLFix g, const GLFix b);
@@ -162,6 +169,7 @@ void nglDrawTriangleZClipped(const VERTEX *low, const VERTEX *middle, const VERT
 void nglInterpolateVertexZ(const VERTEX *from, const VERTEX *to, VERTEX *res);
 void nglDrawLine3D(const VERTEX *v1, const VERTEX *v2);
 
+void nglSetProjectionMode(GLProjectionMode mode);
 void nglPerspective(VERTEX *v);
 void nglPerspective(VECTOR3 *v);
 void nglMultMatVectRes(const MATRIX *mat1, const VERTEX *vect, VERTEX *res);

--- a/gl.h
+++ b/gl.h
@@ -111,6 +111,12 @@ public:
 #define GL_COLOR_BUFFER_BIT 1<<0
 #define GL_DEPTH_BUFFER_BIT 1<<1
 
+enum GLProjectionMode
+{
+    GL_PROJECTION_PERSPECTIVE,
+    GL_PROJECTION_ORTHOGRAPHIC
+};
+
 enum GLDrawMode
 {
     GL_TRIANGLES,
@@ -131,13 +137,6 @@ struct RGB
     extern volatile unsigned int fps;
 #endif
 extern MATRIX *transformation;
-
-enum GLProjectionMode
-{
-    GL_PROJECTION_PERSPECTIVE,
-    GL_PROJECTION_ORTHOGRAPHIC
-};
-
 
 RGB rgbColor(const COLOR c);
 COLOR colorRGB(const RGB rgb);


### PR DESCRIPTION
Orthographic mode can now be set using `nglSetProjectionMode(GLProjectionMode::GL_PROJECTION_ORTHOGRAPHIC)`
And can be reset with `GL_PROJECTION_PERSPECTIVE`.

Also cleaned up one compiler warning with `is_monochrome` as it is never used on non-nspire systems